### PR TITLE
Update read_write_lock.py

### DIFF
--- a/chromadb/utils/read_write_lock.py
+++ b/chromadb/utils/read_write_lock.py
@@ -26,7 +26,7 @@ class ReadWriteLock:
         try:
             self._readers -= 1
             if not self._readers:
-                self._read_ready.notifyAll()
+                self._read_ready.notify_all()
         finally:
             self._read_ready.release()
 


### PR DESCRIPTION
Got this Warning: 
PASSED                                                                                                                                                                  [100%]

============================================================================== warnings summary =============================================================================== test_post.py::test_lookup_values
test_post.py::test_lookup_values
test_post.py::test_lookup_values
  /home/philipp/dev/ai-vertragsdaten/.venv/lib/python3.10/site-packages/chromadb/utils/read_write_lock.py:29: DeprecationWarning: notifyAll() is deprecated, use notify_all() instead
    self._read_ready.notifyAll()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html ================================================================= 1 passed, 2 deselected, 3 warnings in 3.30s ================================================================= (.venv) philipp@000560:~/dev/ai-vertragsdaten/02_fastapi_prototype$ pytest -k test_lookup_values



## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Warning fixed
 - New functionality
	 - no 

- So in my code this removes the warning. 
Changed notifyAll() to notify_all()

## Test plan
*How are these changes tested?*
pytest during a fastAPI interagtion - all tests passed after this change.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
